### PR TITLE
Patstat2016b support

### DIFF
--- a/load_patstat.sh
+++ b/load_patstat.sh
@@ -177,6 +177,7 @@ function main(){
     load_table tls204_appln_prior
     load_table tls205_tech_rel
     load_table tls206_person
+    load_table tls904_nuts
     load_table tls906_person  # this is person table with harmonized names
     load_table tls207_pers_appln
     load_table tls209_appln_ipc

--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -399,11 +399,21 @@ CREATE TABLE tls902_ipc_nace2 (
 
 
 
+CREATE TABLE tls904_nuts (
+  nuts3 char(5) NOT NULL, 
+  nuts3_name varchar(250) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (nuts3)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ;
+
+
+
 CREATE TABLE tls906_person (
   person_id int(11) NOT NULL DEFAULT '0',
   person_name varchar(300) COLLATE utf8mb4_unicode_ci NOT NULL,
   person_address varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL,
   person_ctry_code char(2) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  nuts char(5) NOT NULL DEFAULT '',
+  nuts_level smallint  NOT NULL DEFAULT '9',
   doc_std_name_id int(11) NOT NULL DEFAULT '0',
   doc_std_name varchar(500) COLLATE utf8mb4_unicode_ci NOT NULL,
   psn_id int(11) NOT NULL DEFAULT '0',
@@ -415,6 +425,7 @@ CREATE TABLE tls906_person (
   han_harmonized int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (person_id),
   KEY IX_ppat_person_ctry_code (person_ctry_code),
+  KEY IX_ppat_nuts (nuts),
   KEY IX_ppat_psn_name (psn_name(333)),
   KEY IX_ppat_psn_sector (psn_sector),
   KEY IX_ppat_psn_id (psn_id),

--- a/tools/create_schema.sh
+++ b/tools/create_schema.sh
@@ -44,7 +44,9 @@ CREATE TABLE tls201_appln (
   KEY IX_appln_filing_date (appln_filing_date),
   KEY IX_appln_kind (appln_kind),
   KEY IX_docdb_family_id (docdb_family_id),
-  KEY IX_inpadoc_family_id (inpadoc_family_id)
+  KEY IX_inpadoc_family_id (inpadoc_family_id),
+  KEY IX_docdb_family_id_filing_date (docdb_family_id,appln_filing_date),
+  KEY IX_inpadoc_family_id_filing_date (inpadoc_family_id,appln_filing_date)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ;
 
 


### PR DESCRIPTION
Hi,
this pull request provides compatibility with patstat2016b, the autumn release.

The only notable difference is the NUTS support for patent roles, which adds geolocalization's info.

Merge it while is hot!

--Leo